### PR TITLE
[ENTESB-2289] Added roles for admin to install script

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -172,7 +172,7 @@ else
 fi
 
 # Store password
-echo "admin=${OPENSHIFT_FUSE_PASSWORD},admin" > $FUSE_USRPROPS_FILE
+echo "admin=${OPENSHIFT_FUSE_PASSWORD},admin,manager,viewer,Operator, Maintainer, Deployer, Auditor, Administrator, SuperUser" > $FUSE_USRPROPS_FILE
 echo "${OPENSHIFT_FUSE_PASSWORD}" > $FUSE_PASSWD_FILE
 echo "zookeeper.password=${OPENSHIFT_FUSE_PASSWORD}" >> $FUSE_SYSPROPS_FILE
 


### PR DESCRIPTION
Should add all roles for admin user as 6.2 uses RBA.
